### PR TITLE
Mar 11: Hash functions Lecture 2, Random oracle model

### DIFF
--- a/notes/hash/all.tex
+++ b/notes/hash/all.tex
@@ -15,3 +15,4 @@
 \newpage
 \input{hash/preimage-resistance}
 \input{hash/hash-prf}
+\input{hash/exercises}

--- a/notes/hash/all.tex
+++ b/notes/hash/all.tex
@@ -12,5 +12,6 @@
 }
 
 \input{hash/sponge}
+\newpage
 \input{hash/preimage-resistance}
 \input{hash/hash-prf}

--- a/notes/hash/all.tex
+++ b/notes/hash/all.tex
@@ -12,3 +12,5 @@
 }
 
 \input{hash/sponge}
+\input{hash/preimage-resistance}
+\input{hash/hash-prf}

--- a/notes/hash/all.tex
+++ b/notes/hash/all.tex
@@ -1,0 +1,14 @@
+%!TEX root = ../main.tex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\tikzset{XOR/.style={thick,
+					draw,
+					circle,
+					append after command={
+					        [shorten >=\pgflinewidth, shorten <=\pgflinewidth,]
+					        (\tikzlastnode.north) edge[thick] (\tikzlastnode.south)
+					        (\tikzlastnode.east) edge[thick] (\tikzlastnode.west)
+        				},
+    				},
+}
+
+\input{hash/sponge}

--- a/notes/hash/exercises.tex
+++ b/notes/hash/exercises.tex
@@ -1,0 +1,9 @@
+%!TEX root = ../main.tex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\section*{Exercises}
+
+\begin{enumerate}[label=\textbf{Exercise \thesection.\arabic*}, wide=0pt]
+  \item Show the reductions $\CR\Rightarrow\SPR$ and $\SPR\Rightarrow\OWF$.
+  \item Show the separations $\OWF\not\Rightarrow\SPR$ and $\SPR\not\Rightarrow\CR$.
+\end{enumerate}

--- a/notes/hash/hash-prf.tex
+++ b/notes/hash/hash-prf.tex
@@ -1,0 +1,89 @@
+%!TEX root = ../main.tex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\subsection{Hash-based PRF and the Random Oracle Model}
+
+\begin{tikzpicture}[scale=0.4]
+	\node[draw,trapezium,trapezium left angle=70,trapezium right angle=70,minimum height=1.0cm,thick,shift={(1.15,0)},rotate=-90] (hfxn)
+	{\begin{sideways}\Large $\hash$ \end{sideways}};
+	\draw[->,thick] (0,0) node[left] {$\prfkey \concat \msg$} -- (hfxn);
+	\draw[->,thick] (hfxn) -- ++(3,0) node[right] {$Y$};
+\end{tikzpicture}
+
+\hfpages{.25}{
+\underline{$\PRF1_{F,\Horacle}^\advA$}\\
+$K \getsr \keyspace$\\
+$b' \getsr \advA^{\Fn,\Horacle}$\\
+Return $b'$\medskip
+
+\underline{$\Fn(M)$}\\
+Return $F^\Horacle_K(M)$\medskip
+
+\underline{$\Horacle(X)$}\\
+If $\TabH[X] = \bot$ then\\
+\myInd $\TabH[X] \getsr \bits^n$\\
+Ret $\TabH[X]$
+
+}{
+\underline{$\PRF0_{F,\Horacle}^\advA$}\\
+$\rho \getsr \Func(\msgspace,n)$\\
+$b' \getsr \advA^{\Fn,\Horacle}$\\
+Return $b'$\medskip
+
+\underline{$\Fn(M)$}\\
+Return $\rho(M)$\\
+
+\underline{$\Horacle(X)$}\\
+If $\TabH[X] = \bot$ then\\
+\myInd $\TabH[X] \getsr \bits^n$\\
+Ret $\TabH[X]$
+}
+
+
+\begin{theorem}
+Let  $\Horacle\Colon\msgspace\rightarrow\bits^n$ be modeled as a random oracle
+and let $F^\Horacle\Colon\keyspace\times\msgspace\rightarrow\bits^n$ be the
+hash-based PRF defined as $F^\Horacle(K,M) = \Horacle(K \concat M)$.
+Then for any $\PRF_{F,\Horacle}$-adversary $\advA$ making at most $q$ queries
+to $\Horacle$ it holds that
+\bnm
+  \AdvPRF{F,\Horacle}{\advA} \le \frac{q}{|\keyspace|} \;.
+\enm
+\end{theorem}
+
+\begin{tikzpicture}[scale=0.4]
+
+	\begin{scope}[]
+		\node [draw,trapezium,trapezium left angle=50,trapezium right angle=90,minimum height=0.75cm,thick,shift={(1.15,0.3)},rotate=-90]
+		{\begin{sideways}\Large$f$\end{sideways}};
+		\draw[->,thick] ++(0.5,+4) node[above] {$\prfkey$} -- ++(0,-1.5) -- ++(1.4,0);
+		\draw[->,thick] ++(0,0.5) node[left] {$\IV$} -- ++(1.9,0);
+	\end{scope}
+
+	\begin{scope}[shift={(3.8,0)}]
+		\node [draw,trapezium,trapezium left angle=50,trapezium right angle=90,minimum height=0.75cm,thick,shift={(1.35,0.3)},rotate=-90]
+		{\begin{sideways}\Large$f$\end{sideways}};
+		\draw[->,thick] ++(0.9,+4) node[above] {$\msg_1$} -- ++(0,-1.5) -- ++(1.4,0);
+		\draw[->,thick] ++(0,0.5) -- ++(2.4,0);
+	\end{scope}
+
+	\begin{scope}[shift={(8.2,0)}]
+		\node [draw,trapezium,trapezium left angle=50,trapezium right angle=90,minimum height=0.75cm,thick,shift={(1.35,0.3)},rotate=-90]
+		{\begin{sideways}\Large$f$\end{sideways}};
+		\draw[->,thick] ++(0.9,+4) node[above] {$\qquad\msg_2 \concat 10^r \concat \bm{\langle} \left| \msg \right| \bm{\rangle}$} -- ++(0,-1.5) -- ++(1.4,0);
+		\draw[->,thick] ++(0,0.5) -- ++(2.4,0);
+		\draw[->,thick] ++(4.4,0.5) -- ++(2,0) node[right] {$Y$};
+	\end{scope}
+
+\end{tikzpicture}
+
+\begin{tikzpicture}[scale=0.4]
+
+	\begin{scope}[]
+		\node [draw,trapezium,trapezium left angle=50,trapezium right angle=90,minimum height=0.75cm,thick,shift={(1.15,0.3)},rotate=-90]
+		{\begin{sideways}\Large$f$\end{sideways}};
+		\draw[->,thick] ++(0.5,+4) node[above] {$\qquad\msg^* \concat 10^{r'} \concat \bm{\langle} \left| \msg' \right| \bm{\rangle}$} -- ++(0,-1.5) -- ++(1.4,0);
+		\draw[->,thick] ++(0,0.5) node[left] {$Y$} -- ++(1.9,0);
+		\draw[->,thick] ++(4.4,0.5) -- ++(2,0) node[right] {$Y'$};
+	\end{scope}
+
+\end{tikzpicture}

--- a/notes/hash/hash-prf.tex
+++ b/notes/hash/hash-prf.tex
@@ -60,7 +60,7 @@ to $\Horacle$ it holds that
 	\end{scope}
 
 	\begin{scope}[shift={(3.8,0)}]
-		\node [draw,trapezium,trapezium left angle=50,trapezium right angle=90,minimum height=0.75cm,thick,shift={(1.35,0.3)},rotate=-90]
+		\node [draw,trapezium,trapezium left angle=50,trapezium right angle=90,minimum height=0.75cm,thick,shift={(1.35,0.3)},rotate=-90] (centerbox)
 		{\begin{sideways}\Large$f$\end{sideways}};
 		\draw[->,thick] ++(0.9,+4) node[above] {$\msg_1$} -- ++(0,-1.5) -- ++(1.4,0);
 		\draw[->,thick] ++(0,0.5) -- ++(2.4,0);
@@ -74,16 +74,15 @@ to $\Horacle$ it holds that
 		\draw[->,thick] ++(4.4,0.5) -- ++(2,0) node[right] {$Y$};
 	\end{scope}
 
-\end{tikzpicture}
-
-\begin{tikzpicture}[scale=0.4]
-
-	\begin{scope}[]
+	\begin{scope}[shift={(7, -9)}]
 		\node [draw,trapezium,trapezium left angle=50,trapezium right angle=90,minimum height=0.75cm,thick,shift={(1.15,0.3)},rotate=-90]
 		{\begin{sideways}\Large$f$\end{sideways}};
 		\draw[->,thick] ++(0.5,+4) node[above] {$\qquad\msg^* \concat 10^{r'} \concat \bm{\langle} \left| \msg' \right| \bm{\rangle}$} -- ++(0,-1.5) -- ++(1.4,0);
-		\draw[->,thick] ++(0,0.5) node[left] {$Y$} -- ++(1.9,0);
-		\draw[->,thick] ++(4.4,0.5) -- ++(2,0) node[right] {$Y'$};
+		\draw[->,thick] ++(4.2,0.5) -- ++(2,0) node[right] {$Y'$};
 	\end{scope}
+
+	\draw[->,thick] (16,0.5) -- ++(1,0) -- ++(0, -3) -- ++(-15, 0) -- ++(0, -6) -- ++(6.9,0);
+	\path (2, -11) node[anchor=west] {$\msg = \msg_1\concat\msg_2$};
+	\path (1.8, -12.5) node[anchor=west] {$\msg' = \msg_1\concat\msg_2\concat 10^r\concat\bm{\langle}\left|\msg\right|\bm{\rangle}\concat\msg^*$};
 
 \end{tikzpicture}

--- a/notes/hash/hash-prf.tex
+++ b/notes/hash/hash-prf.tex
@@ -2,15 +2,33 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Hash-based PRF and the Random Oracle Model}
 
+\begin{wrapfigure}{r}{2in}
+  \centering
 \begin{tikzpicture}[scale=0.4]
 	\node[draw,trapezium,trapezium left angle=70,trapezium right angle=70,minimum height=1.0cm,thick,shift={(1.15,0)},rotate=-90] (hfxn)
 	{\begin{sideways}\Large $\hash$ \end{sideways}};
 	\draw[->,thick] (0,0) node[left] {$\prfkey \concat \msg$} -- (hfxn);
 	\draw[->,thick] (hfxn) -- ++(3,0) node[right] {$Y$};
 \end{tikzpicture}
+\caption{Simple hash-based PRF.}
+\label{fig:hash-based-prf}
+\end{wrapfigure}
 
-\hfpages{.25}{
-\underline{$\PRF1_{F,\Horacle}^\advA$}\\
+Another property that is often desired of hash functions is that of a PRF.
+Consider a simple hash-based PRF construction, $\prf:\keyspace\times\msgspace\rightarrow\bits^{n}$, constructed from a hash function $\hash:\bits^{*}\rightarrow\bits^{n}$ such that $\prf_{\prfkey}(\msg) = \hash(\prfkey\concat\msg)$.
+
+Now we can consider how to prove the PRF security of $\prf$.
+One approach would be to instantiate $\hash$ with a specific hash function construction, e.g. SHA-2 or SHA-3, and prove security with respect to the building blocks of those constructions, e.g. PRF security of the compression function or PRP security of the permutation.
+However, this would not be a modular approach, as a new proof would be required for each hash function.
+Instead, we will use a similar approach to as when we proved the PRF security of the Davies-Meyer compression function.
+\scribenote{Add reference}
+There we introduced an idealized model for the block cipher, called the ideal cipher model.
+Here, we will introduce another idealized model known as the \emph{random oracle model} (ROM), in which we, as the name suggests, model the hash function as a random oracle.
+
+\begin{wrapfigure}{r}{2in}
+  \centering
+\hfpages{.15}{
+\underline{$\PRF1_{\prf,\Horacle}^\advA$}\vspace{0.5em}\\
 $K \getsr \keyspace$\\
 $b' \getsr \advA^{\Fn,\Horacle}$\\
 Return $b'$\medskip
@@ -21,10 +39,10 @@ Return $F^\Horacle_K(M)$\medskip
 \underline{$\Horacle(X)$}\\
 If $\TabH[X] = \bot$ then\\
 \myInd $\TabH[X] \getsr \bits^n$\\
-Ret $\TabH[X]$
+Return $\TabH[X]$
 
 }{
-\underline{$\PRF0_{F,\Horacle}^\advA$}\\
+\underline{$\PRF0_{F,\Horacle}^\advA$}\vspace{0.3em}\\
 $\rho \getsr \Func(\msgspace,n)$\\
 $b' \getsr \advA^{\Fn,\Horacle}$\\
 Return $b'$\medskip
@@ -35,9 +53,17 @@ Return $\rho(M)$\\
 \underline{$\Horacle(X)$}\\
 If $\TabH[X] = \bot$ then\\
 \myInd $\TabH[X] \getsr \bits^n$\\
-Ret $\TabH[X]$
+Return $\TabH[X]$
 }
+\caption{PRF security games in the random oracle model.}
+\label{fig:prf-ro}
+\end{wrapfigure}
 
+Consider the modified PRF security games shown in Figure~\ref{fig:prf-ro}.
+In the ROM, a new oracle $\Horacle$ is added to the security game.
+Calling the hash function is done by sending queries to $\Horacle$.
+The random oracle $\Horacle$ is instantiated lazily by maintaining a table $\TabH$, randomly sampling and storing in $\TabH$ return values for new queries.
+We prove the following theorem about the security of the hash-based PRF in the random oracle model:
 
 \begin{theorem}
 Let  $\Horacle\Colon\msgspace\rightarrow\bits^n$ be modeled as a random oracle
@@ -50,6 +76,87 @@ to $\Horacle$ it holds that
 \enm
 \end{theorem}
 
+
+\begin{wrapfigure}{r}{3.8in}
+  \centering
+\hfpagesss{.15}{.18}{.15}{
+\underline{$\G0$}\vspace{0.5em}\\
+$\prfkey \getsr \keyspace$\\
+$b' \getsr \advA^{\Fn,\Horacle}$\\
+Return $b'$\medskip
+
+\underline{$\Fn(\msg)$}\\
+Return $\Horacle(\prfkey\concat\msg)$\medskip
+
+\underline{$\Horacle(X)$}\\
+If $\TabH[X] = \bot$ then\\
+\myInd $\TabH[X] \getsr \bits^n$\\
+Return $\TabH[X]$
+
+}{
+\underline{$\fbox{\G1}$\;\;$\G2$}\vspace{0.5em}\\
+$\prfkey \getsr \keyspace$\\
+$b' \getsr \advA^{\Fn,\Horacle}$\\
+Return $b'$\medskip
+
+\underline{$\Fn(\msg)$}\\
+If $\TabT[\prfkey\concat\msg] = \bot$ then\\
+\myInd $\TabT[\prfkey\concat\msg]\getsr \bits^{n}$\\
+Return $\TabT[\prfkey\concat\msg]$\medskip
+
+\underline{$\Horacle(X)$}\\
+If $\TabT[X]\neq\bot$ then\\
+\myInd $\badtrue$\\
+\myInd \fbox{$\TabH[X]\gets\TabT[X]$}\\
+If $\TabH[X] = \bot$ then\\
+\myInd $\TabH[X] \getsr \bits^n$\\
+Return $\TabH[X]$
+
+}{
+\underline{$\G3$}\vspace{0.3em}\\
+$\rho \getsr \Func(\msgspace,n)$\\
+$b' \getsr \advA^{\Fn,\Horacle}$\\
+Return $b'$\medskip
+
+\underline{$\Fn(M)$}\\
+Return $\rho(M)$\\
+
+\underline{$\Horacle(X)$}\\
+If $\TabH[X] = \bot$ then\\
+\myInd $\TabH[X] \getsr \bits^n$\\
+Return $\TabH[X]$
+}
+\caption{PRF security games in the random oracle model.}
+\label{fig:hash-prf-games}
+\end{wrapfigure}
+
+\emph{Proof.}
+Consider the set of games given in Figure~\ref{fig:hash-prf-games}.
+Game \G0 is identical to $\PRF1_{\prf,\Horacle}$ with pseudocode for the PRF oracle $\Fn$ filled in to represent the hash-based PRF.
+In Game \G1, the PRF oracle does not call the random oracle, but instead maintains a separate table $\TabT$ to respond to queries with random values.
+If the random oracle $\Horacle$ is called with a key\dash message pair that is stored in $\TabT$, a $\bad$ flag is set and the random value sampled in $\Fn$ is copied over and $\Horacle$ responds in a consistent manner.
+Since the value is copied over from $\TabT$ to $\TabH$, \G1 is identical to \G0.
+
+Game \G2 is identical until $\bad$ to \G1.
+Instead of copying the value from $\TabT$ to $\TabH$, a new random value is sampled.
+By the fundamental lemma of game playing, we bound the difference in advantage between \G1 and \G2 by the probability the $\bad$ flag is set.
+To set the $\bad$ flag, $\advA$ must make a query to $\Horacle$ that begins with PRF key $\prfkey$.
+Since only random values are returned, $\advA$ has no knowledge of $\prfkey$, so on any given query, the probability the $\bad$ flag is set is $1/\abs{\keyspace}$.
+Thus, over $q$ queries, using the union bound we have
+\begin{align*}
+	\absv*{\Prob{\G1\Rightarrow 1} - \Prob{\G2\Rightarrow1}} &\le \Prob{\G1 \setsbad}\\
+  &\le \frac{q}{\abs{\keyspace}}.
+\end{align*}
+
+Lastly, \G2 is identical to \G3 is identical to $\PRF0_{\prf,\Horacle}$.
+Since the values $\TabH$ is not updated with the values from $\TabT$ both $\Fn$ and $\Horacle$ act as independent random functions.\hfill$\dqed$
+
+So we've proved security of the hash-based PRF security when the hash function is modeled by a random oracle.
+However, how do we gain confidence that the random oracle model fits for specific hash functions?
+In other words, if we prove a protocol secure with respect to the random oracle model, is it safe to instantiate the random oracle with a hash function such as SHA-2 or SHA-3?
+In the case of the ideal cipher model, we gain confidence through use of cryptanalysis of specific block ciphers.
+
+\begin{wrapfigure}{r}{2.9in}
 \begin{tikzpicture}[scale=0.4]
 
 	\begin{scope}[]
@@ -86,3 +193,19 @@ to $\Horacle$ it holds that
 	\path (1.8, -12.5) node[anchor=west] {$\msg' = \msg_1\concat\msg_2\concat 10^r\concat\bm{\langle}\left|\msg\right|\bm{\rangle}\concat\msg^*$};
 
 \end{tikzpicture}
+\caption{Length extension attack when instantiating the proposed hash-based PRF construction with a Merkle-Damg\aa rd hash function.}
+\label{fig:length-extension-md}
+\end{wrapfigure}
+
+In fact, this can be a problem in practice, as real hash functions often do not act as random oracles, i.e., there exist attacks that take advantage of the structure of the hash function.
+Take the example of instantiating the hash-based PRF that we just proved secure in the random oracle model with the Merkle-Damg\aa rd function.
+This construction is distinguishable from a PRF through a straightforward length extension attack.
+The attack is depicted in Figure~\ref{fig:length-extension-md}.
+The output of the Merkle\dash Damg\aa rd hash function on one message can be chained into computing the output for a longer message without knowledge of the secret key.
+
+There are variants of the basic Merkle\dash Damg\aa rd hash function that can be used to instantiate the hash-based construction, but this leads us to a larger question.
+If not all hash functions are properly modeled by the random oracle model, how do we proceed?
+As mentioned before, a non-modular approach would be to prove protocols without the random oracle model.
+Another approach is to build hash functions that are better modeled by the random oracle model.
+This is a notion known as indifferentiability and we will look at more closely later in the section.
+One of the strengths of the sponge construction from Figure~\ref{fig:sponge} is that it meets this indifferentiability property.

--- a/notes/hash/preimage-resistance.tex
+++ b/notes/hash/preimage-resistance.tex
@@ -1,0 +1,33 @@
+%!TEX root = ../main.tex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{Further Security Properties for Hash Functions}
+
+\subsection{Preimage and Second Preimage Resistance}
+
+\fpage{.25}{
+\underline{$\OWF^\advA_{\hash}$}\\[1pt]
+$M \getsr \msgspace$\\
+$Y \gets \hash(M)$\\
+$M' \getsr \advA(Y)$\\
+Ret $(\hash(M') = Y)$
+}
+
+
+\bnm
+\AdvOWF{\hash}{\advA} = \Prob{\OWF^\advA_{\hash}\Rightarrow\true}
+\enm
+
+
+
+\fpage{.25}{
+\underline{$\SPR^\advA_{\hash}$}\\[1pt]
+$M \getsr \msgspace$\\
+$Y \gets \hash(M)$\\
+$M' \getsr \advA(M)$\\
+Ret $(\hash(M') = \hash(M)) \land (M \ne M')$
+}
+
+
+\bnm
+\AdvSPR{\hash}{\advA} = \Prob{\SPR^\advA_{\hash}\Rightarrow\true}
+\enm

--- a/notes/hash/preimage-resistance.tex
+++ b/notes/hash/preimage-resistance.tex
@@ -2,32 +2,47 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Further Security Properties for Hash Functions}
 
+Hash functions are used to accomplish a wide array tasks in cryptography that require properties stronger than, weaker than, and orthogonal to just collision resistance.
+In this section, we will examine a few of these alternate security goals for hash functions and their relations to each other.
+
 \subsection{Preimage and Second Preimage Resistance}
 
-\fpage{.25}{
+Preimage resistance, often known as ``one-wayness'' of a one-way function, means that given an output $Y$ of a function $\hash$, it is hard to invert $\hash$ and find an element of the domain space that evaluates to $Y$, i.e., it is hard to find any preimage of $Y$.
+Second preimage resistance means that given a domain element and function $\hash$, it is hard to find a second domain element that evaluates to the same output $Y$ for both domain elements, i.e., it is hard to find a second preimage of $Y$ even if already given one preimage.
+Pseudocode for preimage resistance and second preimage resistance, $\OWF$ and $\SPR$, respectively, is given in Figure~\ref{fig:preimage-resistance}.
+The advantage of an adversary against these games is defined as:
+\bnm
+\AdvOWF{\hash}{\advA} = \Prob{\OWF^\advA_{\hash}\Rightarrow\true}\hspace{2em}\text{and}\hspace{2em}\AdvSPR{\hash}{\advA} = \Prob{\SPR^\advA_{\hash}\Rightarrow\true}\;.
+\enm
+
+\begin{wrapfigure}{r}{3.5in}
+  \centering
+\hfpagess{.2}{.3}{
 \underline{$\OWF^\advA_{\hash}$}\\[1pt]
 $M \getsr \msgspace$\\
 $Y \gets \hash(M)$\\
 $M' \getsr \advA(Y)$\\
-Ret $(\hash(M') = Y)$
-}
-
-
-\bnm
-\AdvOWF{\hash}{\advA} = \Prob{\OWF^\advA_{\hash}\Rightarrow\true}
-\enm
-
-
-
-\fpage{.25}{
+Return $(\hash(M') = Y)$
+}{
 \underline{$\SPR^\advA_{\hash}$}\\[1pt]
 $M \getsr \msgspace$\\
 $Y \gets \hash(M)$\\
 $M' \getsr \advA(M)$\\
-Ret $(\hash(M') = \hash(M)) \land (M \ne M')$
+Return $(\hash(M') = \hash(M)) \land (M \ne M')$
 }
+\caption{
+Security games for Preimage resistance (left) and second preimage resistance (right).
+}
+\label{fig:preimage-resistance}
+\end{wrapfigure}
 
-
-\bnm
-\AdvSPR{\hash}{\advA} = \Prob{\SPR^\advA_{\hash}\Rightarrow\true}
-\enm
+These definitions, along with collision resistance, are certainly closely related.
+We can think about how they compare to each other.
+For example, we might conjecture $\CR\Rightarrow\SPR$.
+Thinking about the contrapositive, if one can find a second preimage of an output $Y$ than those two preimages constitute a collision.
+It turns out that we can formally show the following relations: $\CR\Rightarrow\SPR\Rightarrow\OWF$;
+and furthermore, there exist separations for the opposite direction: $\OWF\not\Rightarrow\SPR\not\Rightarrow\CR$.
+Formally showing these implications and separations is left as an exercise.
+Note that these results hold specifically for the definitions of preimage resistance, second preimage resistance, and collision resistance given in this book.
+While they are perhaps the most common such definitions, there exist several nuanced alternate definitions for these notions in the literature that do not satisfy the above implications.
+Rogaway and Shrimpton~\cite{RogawayShrimpton04} explore the landscape of these definitions.

--- a/notes/hash/sponge.tex
+++ b/notes/hash/sponge.tex
@@ -1,0 +1,83 @@
+%!TEX root = ../main.tex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\subsection{Sponge Construction}
+
+\begin{tikzpicture}[scale=0.45]
+
+\tikzset{SpongePerm/.style=rounded corners=4pt,};
+%\tikzset{edge/.style=-latex new, arrow head=8pt, thick};
+%\tikzset{edgee/.style=latex new-latex new, arrow head=8pt, thick};
+\tikzset{edge/.style=->, thick};
+\tikzset{edgee/.style=<->, thick};
+
+\path (12.5, -1) node {absorbing phase};
+\path (21.5, -1) node {squeezing phase};
+
+%%
+\begin{scope}[xshift=0cm]
+  \draw[thick] (0,0) rectangle node {$0$} ++(1,3);
+  \draw[thick] (0,3) rectangle node {$0$} ++(1,7);
+
+  \node[XOR,thick] (xm0) at (1+1.5,8) {};
+  \draw[edge,thick] (1,8) -- (xm0);
+  \draw[edge,thick] (1,2) -- ++(3,0);
+  \draw[edge,thick] (1+1.5,10.5) node[above] {\large $m_{0}$} -- (xm0);
+  \draw[edge,thick] (xm0) -- ++(1.5,0);
+
+	\draw[edgee,anchor=east] (-1,0) -- node[left] {$c$ bits} ++(0,3);
+	\draw[edgee,anchor=east] (-1,3) -- node[left] {$r$ bits} ++(0,7);
+
+\end{scope}
+
+\foreach \z in {1,2} {
+  \begin{scope}[xshift=\z*4cm]
+    \draw[SpongePerm]
+    		(0,0) rectangle node {\large$f$} ++(1,10);
+  \end{scope}
+}
+
+\foreach \z in {4,11} {
+  \begin{scope}[xshift=\z*1cm]
+    \node[XOR,thick] (xm\z) at (1+1.5,8) {};
+    \draw[edge,thick] (1,8) -- (xm\z);
+    \draw[edge,thick] (1,2) -- ++(3,0);
+    \draw[edge,thick] (xm\z) -- ++(1.5,0);
+  \end{scope}
+}
+\draw[edge,thick] (5+1.5,10.5) node[above] {\large $m_{1}$} -- (xm4);
+\draw[edge,thick] (12+1.5,10.5) node[above] {\large $m_{n-1}$} -- (xm11);
+
+\begin{scope}[xshift=8cm]
+  \draw[edge,thick] (1,2) -- ++(1.5,0) node[right] {$\dots$};
+  \draw[edge,thick] (1,8) -- ++(1.5,0) node[right] {$\dots$};
+\end{scope}
+
+%%
+\begin{scope}[xshift=15cm]
+  \draw[SpongePerm]
+  		(0,0) rectangle node {\large$f$} ++(1,10);
+
+  \draw[thick] (1,2) -- ++(1,0);
+  \draw[thick] (1,8) -- ++(1,0);
+  \draw[dashed,thick] (2,-2) -- ++(0,14);
+\end{scope}
+%%
+
+\foreach \z in {0,1} {
+  \begin{scope}[xshift=\z*4cm+17cm]
+    \draw[edge,thick] (0,2) -- ++(3,0);
+    \draw[edge,thick] (0,8) -- ++(3,0);
+    \draw[edge,thick] (0+1.5,8) -- ++(0,2.5) node[above] {\large $z_{\z}$};
+    \draw[SpongePerm] (3,0) rectangle node {\large$f$} ++(1,10);
+  \end{scope}
+}
+
+\begin{scope}[xshift=25cm]
+  \draw[edge,thick] (0,2) -- ++(1.5,0) node[right] {$\dots$};
+  \draw[edge,thick] (0,8) -- ++(1.5,0) node[right] {$\dots$};
+  \draw[edge,thick] (3,2) -- ++(1.5,0);
+  \draw[edge,thick] (3,8) -- ++(1.5,0);
+  \draw[SpongePerm] (4.5,0) rectangle node {\large$f$} ++(1,10);
+  \draw[edge,thick] (5.5,8) -- ++(1.5,0) -- ++(0,2.5) node[above] {\large $z_{m-1}$};
+\end{scope}
+\end{tikzpicture}

--- a/notes/hash/sponge.tex
+++ b/notes/hash/sponge.tex
@@ -1,7 +1,29 @@
 %!TEX root = ../main.tex
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Sponge Construction}
+We've seen one popular approach to building hash functions, namely using the Merkle-Damg\aa rd domain extension transform with a compression function such as Davies-Meyer.
+It is the approach used by many standardized hash functions (MD5, SHA-1, SHA-2).
+In this section, we present an alternate design approach to building hash functions called the sponge construction, which is used in the standardized SHA-3 hash function.
+The sponge construction is illustrated in Figure~\ref{fig:sponge}.
 
+The sponge construction maintains an internal state of length $r+c$ bits known as ``rate'' bits ($r$) and ``capacity'' bits ($c$).
+It also makes use of a permutation $f$ on domain $\bits^{r+c}$.
+The sponge construction is executed in two phases, the ``absorbing'' phase and the ``squeezing'' phase.
+One round of the absorbing phase corresponds to XORing a message block of length $r$ with the rate bits and then passing the entire internal state (rate and capacity bits) through permutation $f$ to get a new internal state for the next round.
+The number of rounds, i.e. rate of absorbing, is determined by $r$, the size of blocks into which the message must be broken.
+In the squeezing phase, $r$ bits of the hash digest are read off from the rate bits in each squeezing round.
+Between squeezing rounds, the internal state is again passed through the permutation $f$.
+A nice property that emerges from this approach is that the hash digest size can be chosen as a parameter indicating the number of squeezing rounds to perform.
+
+We will see in the next section that Merkle-Damg\aa rd style constructions are subject to a few subtle ``gotchas'' if used incorrectly, e.g., malleability attacks.
+While there exist fixes to the basic Merkle\dash Damg\aa rd construction to alleviate these concerns, many believe the sponge construction addresses them in a more elegant way leading to a cleaner analysis.
+It turns out that the use of capacity bits as part of the internal state is critical to the security properties of the construction.
+In particular, the capacity bits do not directly interact with inputs and are not directly returned as outputs.
+In contrast, the hash digest of the Merkle\dash Damg\aa rd construction is the complete internal state of the function.
+
+
+\begin{figure}[t]
+  \centering
 \begin{tikzpicture}[scale=0.45]
 
 \tikzset{SpongePerm/.style=rounded corners=4pt,};
@@ -21,7 +43,7 @@
   \node[XOR,thick] (xm0) at (1+1.5,8) {};
   \draw[edge,thick] (1,8) -- (xm0);
   \draw[edge,thick] (1,2) -- ++(3,0);
-  \draw[edge,thick] (1+1.5,10.5) node[above] {\large $m_{0}$} -- (xm0);
+  \draw[edge,thick] (1+1.5,10.5) node[above] {\large $\msg_{0}$} -- (xm0);
   \draw[edge,thick] (xm0) -- ++(1.5,0);
 
 	\draw[edgee,anchor=east] (-1,0) -- node[left] {$c$ bits} ++(0,3);
@@ -44,8 +66,8 @@
     \draw[edge,thick] (xm\z) -- ++(1.5,0);
   \end{scope}
 }
-\draw[edge,thick] (5+1.5,10.5) node[above] {\large $m_{1}$} -- (xm4);
-\draw[edge,thick] (12+1.5,10.5) node[above] {\large $m_{n-1}$} -- (xm11);
+\draw[edge,thick] (5+1.5,10.5) node[above] {\large $\msg_{1}$} -- (xm4);
+\draw[edge,thick] (12+1.5,10.5) node[above] {\large $\msg_{n-1}$} -- (xm11);
 
 \begin{scope}[xshift=8cm]
   \draw[edge,thick] (1,2) -- ++(1.5,0) node[right] {$\dots$};
@@ -67,7 +89,7 @@
   \begin{scope}[xshift=\z*4cm+17cm]
     \draw[edge,thick] (0,2) -- ++(3,0);
     \draw[edge,thick] (0,8) -- ++(3,0);
-    \draw[edge,thick] (0+1.5,8) -- ++(0,2.5) node[above] {\large $z_{\z}$};
+    \draw[edge,thick] (0+1.5,8) -- ++(0,2.5) node[above] {\large $Y_{\z}$};
     \draw[SpongePerm] (3,0) rectangle node {\large$f$} ++(1,10);
   \end{scope}
 }
@@ -78,6 +100,12 @@
   \draw[edge,thick] (3,2) -- ++(1.5,0);
   \draw[edge,thick] (3,8) -- ++(1.5,0);
   \draw[SpongePerm] (4.5,0) rectangle node {\large$f$} ++(1,10);
-  \draw[edge,thick] (5.5,8) -- ++(1.5,0) -- ++(0,2.5) node[above] {\large $z_{m-1}$};
+  \draw[edge,thick] (5.5,8) -- ++(1.5,0) -- ++(0,2.5) node[above] {\large $Y_{m-1}$};
 \end{scope}
 \end{tikzpicture}
+\caption{The sponge construction for hash functions built from permutation $f$, similar to as used in SHA-3.
+Variable size messages are incorporated in a message-length dependent number of absorbing rounds.
+The hash digest is read out in a fixed number of squeezing rounds.
+}
+\label{fig:sponge}
+\end{figure}

--- a/notes/hash/sponge.tex
+++ b/notes/hash/sponge.tex
@@ -3,7 +3,7 @@
 \subsection{Sponge Construction}
 We've seen one popular approach to building hash functions, namely using the Merkle-Damg\aa rd domain extension transform with a compression function such as Davies-Meyer.
 It is the approach used by many standardized hash functions (MD5, SHA-1, SHA-2).
-In this section, we present an alternate design approach to building hash functions called the sponge construction, which is used in the standardized SHA-3 hash function.
+In this section, we will look at an alternate design approach to building hash functions called the sponge construction, which is used in the standardized SHA-3 hash function.
 The sponge construction is illustrated in Figure~\ref{fig:sponge}.
 
 The sponge construction maintains an internal state of length $r+c$ bits known as ``rate'' bits ($r$) and ``capacity'' bits ($c$).
@@ -104,8 +104,8 @@ In contrast, the hash digest of the Merkle\dash Damg\aa rd construction is the c
 \end{scope}
 \end{tikzpicture}
 \caption{The sponge construction for hash functions built from permutation $f$, similar to as used in SHA-3.
-Variable size messages are incorporated in a message-length dependent number of absorbing rounds.
-The hash digest is read out in a fixed number of squeezing rounds.
+Variable size messages are broken into $n$ blocks of size $r$ and incorporated in $n$ absorbing rounds.
+The hash digest of length $mr$ is read out in $m$ squeezing rounds.
 }
 \label{fig:sponge}
 \end{figure}

--- a/notes/main.tex
+++ b/notes/main.tex
@@ -117,6 +117,7 @@
 \input{hashfunctions}
 \newpage
 \input{hashfunctions2}
+\input{hash/all}
 \newpage
 \input{pke}
 

--- a/notes/notes.bib
+++ b/notes/notes.bib
@@ -384,3 +384,13 @@ journal={20thNISSC Proceedings},
 year={1997},
 url={http://csrc.nist.gov/nissc/1997}
 }
+
+@inproceedings{RogawayShrimpton04,
+  author    = {Phillip Rogaway and
+               Thomas Shrimpton},
+  title     = {Cryptographic Hash-Function Basics: Definitions, Implications, and
+               Separations for Preimage Resistance, Second-Preimage Resistance, and
+               Collision Resistance},
+  booktitle = {Fast Software Encryption},
+  year      = {2004},
+}


### PR DESCRIPTION
Outline of scribe breakdown between 3 Hash function lectures:

Lec 1 - Kai

- Intro, applications
- Collision resistance, birthday attacks
- CBC-MAC not CR
- Merkle-Damgard domain extension transform using compression functions
- Compression fxn from block cipher (Davies-Meyers)
- Ideal cipher model (Davies-Meyers secure)

Lec 2 - Nirvan

- Sponge construction (alternative to MD domain extension approach)
- Preimage resistance/ OWF + relation to CR
- PRF from Hash fxn
- Random oracle model (Hash-based PRF secure)
- Hash-based PRF insecure when instantiated with MD-style hash

Lec 3 - Mahimna

- PRF from MD-style:  suffix mac, envelope mac and nested mac
- HMAC construction
- Analysis of HMAC:
   - Proof of security when H is a RO. This might be left as a homework exercise
   - Related key attack security.
   - Proof sketch of security assuming the compression function is a good PRF.
- Random oracle gap. Indifferentiability for hash functions from an RO
- [MRH04] Composition theorem
- Takeaways for hash function design based on the composition theorem